### PR TITLE
all: Group package-level constants and variables definitions

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -14,9 +14,12 @@ import (
 	"sort"
 )
 
-const genPackage = "github.com/kiwicom/easycql/gen"
-const pkgMarshal = "github.com/kiwicom/easycql/marshal"
-const pkgGocql = "github.com/gocql/gocql"
+// package paths to use in generated files.
+const (
+	genPackage = "github.com/kiwicom/easycql/gen"
+	pkgMarshal = "github.com/kiwicom/easycql/marshal"
+	pkgGocql   = "github.com/gocql/gocql"
+)
 
 type Generator struct {
 	PkgPath, PkgName string

--- a/easycql/main.go
+++ b/easycql/main.go
@@ -16,17 +16,20 @@ import (
 	"github.com/kiwicom/easycql/parser"
 )
 
-var buildTags = flag.String("build_tags", "", "build tags to add to generated file")
-var snakeCase = flag.Bool("snake_case", false, "use snake_case names instead of CamelCase by default")
-var lowerCamelCase = flag.Bool("lower_camel_case", false, "use lowerCamelCase names instead of CamelCase by default")
-var allStructs = flag.Bool("all", false, "generate marshaler/unmarshalers for all structs in a file")
-var leaveTemps = flag.Bool("leave_temps", false, "do not delete temporary files")
-var stubs = flag.Bool("stubs", false, "only generate stubs for marshaler/unmarshaler funcs")
-var noformat = flag.Bool("noformat", false, "do not run 'gofmt -w' on output file")
-var specifiedName = flag.String("output_filename", "", "specify the filename of the output")
-var processPkg = flag.Bool("pkg", false, "process the whole package instead of just the given file")
-var disallowUnknownFields = flag.Bool("disallow_unknown_fields", false, "return error if any unknown field in json appeared")
-var conservative = flag.Bool("conservative", false, "be conservative about generated code, mostly falls back to gocql")
+// available cli parameters
+var (
+	buildTags             = flag.String("build_tags", "", "build tags to add to generated file")
+	snakeCase             = flag.Bool("snake_case", false, "use snake_case names instead of CamelCase by default")
+	lowerCamelCase        = flag.Bool("lower_camel_case", false, "use lowerCamelCase names instead of CamelCase by default")
+	allStructs            = flag.Bool("all", false, "generate marshaler/unmarshalers for all structs in a file")
+	leaveTemps            = flag.Bool("leave_temps", false, "do not delete temporary files")
+	stubs                 = flag.Bool("stubs", false, "only generate stubs for marshaler/unmarshaler funcs")
+	noformat              = flag.Bool("noformat", false, "do not run 'gofmt -w' on output file")
+	specifiedName         = flag.String("output_filename", "", "specify the filename of the output")
+	processPkg            = flag.Bool("pkg", false, "process the whole package instead of just the given file")
+	disallowUnknownFields = flag.Bool("disallow_unknown_fields", false, "return error if any unknown field in json appeared")
+	conservative          = flag.Bool("conservative", false, "be conservative about generated code, mostly falls back to gocql")
+)
 
 func generate(fname string) (err error) {
 	fInfo, err := os.Stat(fname)

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -13,10 +13,13 @@ import (
 	"unicode"
 )
 
-const pkgMarshal = "github.com/kiwicom/easycql/marshal"
-const pkgEasyCQL = "github.com/kiwicom/easycql"
-const pkgGoCQL = "github.com/gocql/gocql"
-const pkgInf = "gopkg.in/inf.v0"
+// package paths to use in imports of the generate files.
+const (
+	pkgMarshal = "github.com/kiwicom/easycql/marshal"
+	pkgEasyCQL = "github.com/kiwicom/easycql"
+	pkgGoCQL   = "github.com/gocql/gocql"
+	pkgInf     = "gopkg.in/inf.v0"
+)
 
 // FieldNamer defines a policy for generating names for struct fields.
 type FieldNamer interface {


### PR DESCRIPTION
This commit is required because:
- declaration grouping helps with readability
- gofmt has auto indentation which makes orientation in cli arguments easier

This commit groups some of the constants and variables where it makes sense, for example
command-line arguments has better readability when they are formatted and their values are indented
to the same level.