### PR TITLE
Decapitalize errors

### DIFF
--- a/easycql/main.go
+++ b/easycql/main.go
@@ -39,7 +39,7 @@ func generate(fname string) (err error) {
 
 	p := parser.Parser{AllStructs: *allStructs}
 	if err := p.Parse(fname, fInfo.IsDir()); err != nil {
-		return fmt.Errorf("Error parsing %v: %v", fname, err)
+		return fmt.Errorf("error parsing %v: %v", fname, err)
 	}
 
 	var outName string
@@ -47,7 +47,7 @@ func generate(fname string) (err error) {
 		outName = filepath.Join(fname, p.PkgName+"_easycql.go")
 	} else {
 		if s := strings.TrimSuffix(fname, ".go"); s == fname {
-			return errors.New("Filename must end in '.go'")
+			return errors.New("filename must end in '.go'")
 		} else {
 			outName = s + "_easycql.go"
 		}
@@ -78,7 +78,7 @@ func generate(fname string) (err error) {
 	}
 
 	if err := g.Run(); err != nil {
-		return fmt.Errorf("Bootstrap failed: %v", err)
+		return fmt.Errorf("bootstrap failed: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
These commits are required because:
- Go 1.13 introduced built-in error wrapping which can be used for generating
string with existing error value
- Errors should not be capitalized or start/end with punctuation as they can be wrapped later.

See for more info https://github.com/golang/go/wiki/CodeReviewComments#error-strings