### PR TITLE
Use field names specified in cql tag

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -596,7 +596,6 @@ func reference(out string) string {
 
 //nolint:gocritic // parameter f is huge
 func (g *Generator) genStructFieldDecoder(t reflect.Type, f reflect.StructField) error {
-	cqlName := g.fieldNamer.GetCQLFieldName(t, f)
 	tags, err := parseFieldTags(f)
 	if err != nil {
 		return err
@@ -605,6 +604,8 @@ func (g *Generator) genStructFieldDecoder(t reflect.Type, f reflect.StructField)
 	if tags.omit {
 		return nil
 	}
+
+	cqlName := g.getFieldName(t, f, tags)
 
 	fmt.Fprintf(g.out, "    case %q:\n", cqlName)
 	if err := g.genTypeDecoder(f.Type, "udtElement.Type", "elementData", "out."+f.Name, tags, 3); err != nil {
@@ -635,7 +636,6 @@ func (g *Generator) genRequiredFieldSet(_ reflect.Type, f reflect.StructField) e
 
 //nolint:gocritic // parameter f is huge
 func (g *Generator) genRequiredFieldCheck(t reflect.Type, f reflect.StructField) error {
-	cqlName := g.fieldNamer.GetCQLFieldName(t, f)
 	tags, err := parseFieldTags(f)
 	if err != nil {
 		return err
@@ -644,6 +644,8 @@ func (g *Generator) genRequiredFieldCheck(t reflect.Type, f reflect.StructField)
 	if !tags.required {
 		return nil
 	}
+
+	cqlName := g.getFieldName(t, f, tags)
 
 	g.imports["fmt"] = "fmt"
 

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -291,6 +291,14 @@ func (g *Generator) Run(out io.Writer) error {
 	return err
 }
 
+//nolint:gocritic // parameter f is huge
+func (g *Generator) getFieldName(t reflect.Type, f reflect.StructField, tags fieldTags) string {
+	if tags.name != "" {
+		return tags.name
+	}
+	return g.fieldNamer.GetCQLFieldName(t, f)
+}
+
 // fixes vendored paths
 func fixPkgPathVendoring(pkgPath string) string {
 	const vendor = "/vendor/"


### PR DESCRIPTION
When determining field names, fall back to cql tag. This helps with
gocql compatibility for existing projects so that users don't need to
update cql to easycql tags when only specifing field names.