### PR TITLE
github/workflows: update golangci lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,7 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
-      - name: Run GolangCI-Lint
-        uses: matoous/golangci-lint-action@v1.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
         with:
-          config: .golangci.yml
+          version: v1.36.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,24 +39,50 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    # prealloc is not recommended by `golangci-lint` developers.
+    #  Finds slice declarations that could potentially be preallocated
     - prealloc
     - wsl
     - maligned
     - gochecknoglobals
+    # Checks that errors returned from external packages are wrapped,
+    # can be fixed and removed later but will include a lot of work.
+    - wrapcheck
+    # linter that makes you use a separate _test package.
+    # Most of the tests in this repo are internal, disable this linter.
+    - testpackage
+    # I don't think we need blank line before each return statement.
+    # If you think otherwise feel free to remove this disable statement and fix the issues.
+    - nlreturn
+    # An analyzer to detect magic numbers. We have a lot of "magic numbers" here, used mainly
+    # for type sizes, etc.
+    - gomnd
+    # Golang linter to check the errors handling expressions. We return a lot of dynamic errors because
+    # we the errors will end up in the terminal telling user what went wrong. This linter doesn't make much
+    # sense for CLI tools.
+    - goerr113
+    # Linter for Go software that can be used to find code that will cause problems with the error wrapping scheme
+    # introduced in Go 1.13. Again, for the same reasons as goerr113, we don't need this linter for CLI tool.
+    - errorlint
+    # Checks if all struct fields are initialized. Unnecessarily restrictive.
+    - exhaustivestruct
+    # check exhaustiveness of enum switch statements. This linter would make the switch statements for individual
+    # types super long.
+    - exhaustive
+    # Used to forbid print statements. But we use those to generate code, so no use here.
+    - forbidigo
+    # Gci control golang package import order and make it always deterministic.
+    # Fails because we have comments for some imports.
+    - gci
 
 issues:
   exclude-rules:
-    - path: _test\.go
-      linters:
-        - goconst
-        - dupl
-        - funlen
     - path: tests/*
       linters:
         - deadcode
         - varcheck
         - unused
+        - gomnd
+        - dupl
 
 run:
   modules-download-mode: readonly

--- a/easycql/main.go
+++ b/easycql/main.go
@@ -9,14 +9,15 @@ import (
 	"strings"
 
 	"github.com/kiwicom/easycql/bootstrap"
+	"github.com/kiwicom/easycql/parser"
+
 	// Reference the gen package to be friendly to vendoring tools,
 	// as it is an indirect dependency.
 	// (The temporary bootstrapping code uses it.)
 	_ "github.com/kiwicom/easycql/gen"
-	"github.com/kiwicom/easycql/parser"
 )
 
-// available cli parameters
+// All available cli parameters.
 var (
 	buildTags             = flag.String("build_tags", "", "build tags to add to generated file")
 	snakeCase             = flag.Bool("snake_case", false, "use snake_case names instead of CamelCase by default")

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -22,10 +22,12 @@ func (g *Generator) getDecoderName(t reflect.Type) string {
 // tags describe the field tags for the field being unmarshaled and indent specifies how much to indent the output.
 type decoderGen func(g *Generator, t reflect.Type, info, in, out string, tags fieldTags, indent int) error
 
-var stringType = reflect.TypeOf((*string)(nil)).Elem()
-var byteSliceType = reflect.TypeOf((*[]byte)(nil)).Elem()
-var bigIntType = reflect.TypeOf((*big.Int)(nil)).Elem()
-var infDecType = reflect.TypeOf((*inf.Dec)(nil)).Elem()
+var (
+	stringType    = reflect.TypeOf((*string)(nil)).Elem()
+	byteSliceType = reflect.TypeOf((*[]byte)(nil)).Elem()
+	bigIntType    = reflect.TypeOf((*big.Int)(nil)).Elem()
+	infDecType    = reflect.TypeOf((*inf.Dec)(nil)).Elem()
+)
 
 var decodersByKind = map[reflect.Kind]decoderMeta{
 	reflect.String: {
@@ -487,7 +489,7 @@ func (g *Generator) genTypeDecoder(t reflect.Type, info, in, out string, tags fi
 	return err
 }
 
-// sortTypes sorts types and puts preferred to the first index
+// sortTypes sorts types and puts preferred to the first index.
 func sortTypes(types []gocql.Type, preferred gocql.Type) {
 	if len(types) == 0 {
 		return

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -13,14 +13,13 @@ import (
 	"unicode"
 )
 
-// package paths to use in imports of the generate files.
 const (
+	// package paths to use in imports of the generate files.
 	pkgMarshal = "github.com/kiwicom/easycql/marshal"
 	pkgEasyCQL = "github.com/kiwicom/easycql"
 	pkgGoCQL   = "github.com/gocql/gocql"
 	pkgInf     = "gopkg.in/inf.v0"
-)
-const license = `
+	license    = `
 // ---------------------------------------------------------------------------------------------------------------------
 // OPEN SOURCE ATTRIBUTION
 // ---------------------------------------------------------------------------------------------------------------------
@@ -84,6 +83,7 @@ const license = `
 // ---------------------------------------------------------------------------------------------------------------------
 
 `
+)
 
 // FieldNamer defines a policy for generating names for struct fields.
 type FieldNamer interface {
@@ -299,7 +299,7 @@ func (g *Generator) getFieldName(t reflect.Type, f reflect.StructField, tags fie
 	return g.fieldNamer.GetCQLFieldName(t, f)
 }
 
-// fixes vendored paths
+// fixes vendored paths.
 func fixPkgPathVendoring(pkgPath string) string {
 	const vendor = "/vendor/"
 	if i := strings.LastIndex(pkgPath, vendor); i != -1 {
@@ -362,36 +362,36 @@ func (g *Generator) getType(t reflect.Type) string {
 	}
 
 	if t.Name() == "" || t.PkgPath() == "" {
-		if t.Kind() == reflect.Struct {
-			// the fields of an anonymous struct can have named types,
-			// and t.String() will not be sufficient because it does not
-			// remove the package name when it matches g.pkgPath.
-			// so we convert by hand
-			nf := t.NumField()
-			lines := make([]string, 0, nf)
-			for i := 0; i < nf; i++ {
-				f := t.Field(i)
-				var line string
-				if !f.Anonymous {
-					line = f.Name + " "
-				} // else the field is anonymous (an embedded type)
-				line += g.getType(f.Type)
-				t := f.Tag
-				if t != "" {
-					line += " " + escapeTag(t)
-				}
-				lines = append(lines, line)
-			}
-			return strings.Join([]string{"struct { ", strings.Join(lines, "; "), " }"}, "")
+		if t.Kind() != reflect.Struct {
+			return t.String()
 		}
-		return t.String()
+		// the fields of an anonymous struct can have named types,
+		// and t.String() will not be sufficient because it does not
+		// remove the package name when it matches g.pkgPath.
+		// so we convert by hand
+		nf := t.NumField()
+		lines := make([]string, 0, nf)
+		for i := 0; i < nf; i++ {
+			f := t.Field(i)
+			var line string
+			if !f.Anonymous {
+				line = f.Name + " "
+			} // else the field is anonymous (an embedded type)
+			line += g.getType(f.Type)
+			t := f.Tag
+			if t != "" {
+				line += " " + escapeTag(t)
+			}
+			lines = append(lines, line)
+		}
+		return strings.Join([]string{"struct { ", strings.Join(lines, "; "), " }"}, "")
 	} else if t.PkgPath() == g.pkgPath {
 		return t.Name()
 	}
 	return g.pkgAlias(t.PkgPath()) + "." + t.Name()
 }
 
-// escape a struct field tag string back to source code
+// escape a struct field tag string back to source code.
 func escapeTag(tag reflect.StructTag) string {
 	t := string(tag)
 	if strings.ContainsRune(t, '`') {
@@ -475,7 +475,7 @@ func (DefaultFieldNamer) GetCQLFieldName(t reflect.Type, f reflect.StructField) 
 	return f.Name
 }
 
-// LowerCamelCaseFieldNamer
+// LowerCamelCaseFieldNamer generates lower camel case field names.
 type LowerCamelCaseFieldNamer struct{}
 
 func isLower(b byte) bool {
@@ -486,7 +486,7 @@ func isUpper(b byte) bool {
 	return b >= 65 && b <= 90
 }
 
-// convert HTTPRestClient to httpRestClient
+// convert HTTPRestClient to httpRestClient.
 func lowerFirst(s string) string {
 	if s == "" {
 		return ""

--- a/gen/generator_test.go
+++ b/gen/generator_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCamelToSnake(t *testing.T) {
+	t.Parallel()
 	for i, test := range []struct {
 		In, Out string
 	}{
@@ -32,6 +33,7 @@ func TestCamelToSnake(t *testing.T) {
 }
 
 func TestCamelToLowerCamel(t *testing.T) {
+	t.Parallel()
 	for i, test := range []struct {
 		In, Out string
 	}{
@@ -54,6 +56,7 @@ func TestCamelToLowerCamel(t *testing.T) {
 }
 
 func TestJoinFunctionNameParts(t *testing.T) {
+	t.Parallel()
 	for i, test := range []struct {
 		keepFirst bool
 		parts     []string
@@ -74,6 +77,7 @@ func TestJoinFunctionNameParts(t *testing.T) {
 }
 
 func TestFixVendorPath(t *testing.T) {
+	t.Parallel()
 	for i, test := range []struct {
 		In, Out string
 	}{
@@ -96,6 +100,7 @@ type TestTagsStruct struct {
 }
 
 func TestUseCQLTag(t *testing.T) {
+	t.Parallel()
 	g := NewGenerator("test")
 	g.UseSnakeCase()
 	typ := reflect.TypeOf((*TestTagsStruct)(nil)).Elem()

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -10,10 +10,7 @@ import (
 )
 
 var (
-	bigOne = big.NewInt(1)
-)
-
-var (
+	bigOne              = big.NewInt(1)
 	ErrorUDTUnavailable = errors.New("UDT are not available on protocols less than 3, please update config")
 )
 

--- a/parser/pkgpath.go
+++ b/parser/pkgpath.go
@@ -42,7 +42,7 @@ var goModPathCache = struct {
 	paths: make(map[string]string),
 }
 
-// empty if no go.mod, GO111MODULE=off or go without go modules support
+// empty if no go.mod, GO111MODULE=off or go without go modules support.
 func goModPath(fname string, isDir bool) (string, error) {
 	root := fname
 	if !isDir {

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/kiwicom/easycql/marshal"
 )
 
-var benchmarkUnmarshalOut BenchmarkStruct
-var benchmarkMarshalOut []byte
+var (
+	benchmarkUnmarshalOut BenchmarkStruct
+	benchmarkMarshalOut   []byte
+)
 
 var benchTypeInfo = gocql.UDTTypeInfo{
 	NativeType: gocql.NewNativeType(3, gocql.TypeUDT, ""),

--- a/tests/cql_test.go
+++ b/tests/cql_test.go
@@ -188,9 +188,11 @@ func buildUDT(typ reflect.Type, fieldType gocql.TypeInfo, fieldData []byte, null
 }
 
 func TestUnmarshalVarchar(t *testing.T) {
+	t.Parallel()
 	for _, test := range varcharTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			typeInfo, data := buildUDT(reflect.TypeOf((*CQLVarcharTypes)(nil)).Elem(), test.FieldTypeInfo, test.Data,
 				false)
 			var value CQLVarcharTypes
@@ -202,9 +204,11 @@ func TestUnmarshalVarchar(t *testing.T) {
 }
 
 func TestMarshalVarchar(t *testing.T) {
+	t.Parallel()
 	for _, test := range varcharTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			var data []byte
 			typeInfo, expectedData := buildUDT(reflect.TypeOf((*CQLVarcharTypes)(nil)).Elem(), test.FieldTypeInfo,
 				test.Data, test.NullCheck)
@@ -2461,9 +2465,11 @@ var integerTests = []struct {
 }
 
 func TestUnmarshalInteger(t *testing.T) {
+	t.Parallel()
 	for _, test := range integerTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			typeInfo, data := buildUDT(reflect.ValueOf(test.Value).Type(), test.FieldTypeInfo, test.Data, false)
 			value := reflect.New(reflect.TypeOf(test.Value))
 			err := gocql.Unmarshal(typeInfo, data, value.Interface())
@@ -2737,9 +2743,11 @@ func requireBigIntStructEqual(t *testing.T, expectedIface, actualIface interface
 }
 
 func TestUnmarshalBigInt(t *testing.T) {
+	t.Parallel()
 	for _, test := range bigIntTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			typeInfo, data := buildUDT(reflect.ValueOf(test.Value).Type(), test.FieldTypeInfo, test.Data, false)
 			value := reflect.New(reflect.TypeOf(test.Value))
 			err := gocql.Unmarshal(typeInfo, data, value.Interface())
@@ -2887,9 +2895,11 @@ var booleanTests = []struct {
 }
 
 func TestUnmarshalBoolean(t *testing.T) {
+	t.Parallel()
 	for _, test := range booleanTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			typeInfo, data := buildUDT(reflect.ValueOf(test.Value).Type(), test.FieldTypeInfo, test.Data, false)
 			value := reflect.New(reflect.TypeOf(test.Value))
 			err := gocql.Unmarshal(typeInfo, data, value.Interface())
@@ -3102,9 +3112,11 @@ func requireDecStructEqual(t *testing.T, expectedIface, actualIface interface{})
 }
 
 func TestUnmarshalDec(t *testing.T) {
+	t.Parallel()
 	for _, test := range decimalTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			typeInfo, data := buildUDT(reflect.ValueOf(test.Value).Type(), test.FieldTypeInfo, test.Data, false)
 			value := reflect.New(reflect.TypeOf(test.Value))
 			err := gocql.Unmarshal(typeInfo, data, value.Interface())
@@ -3228,9 +3240,11 @@ var floatTests = []struct {
 }
 
 func TestUnmarshalFloat(t *testing.T) {
+	t.Parallel()
 	for _, test := range floatTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			typeInfo, data := buildUDT(reflect.ValueOf(test.Value).Type(), test.FieldTypeInfo, test.Data, false)
 			value := reflect.New(reflect.TypeOf(test.Value))
 			err := gocql.Unmarshal(typeInfo, data, value.Interface())
@@ -3354,9 +3368,11 @@ var doubleTests = []struct {
 }
 
 func TestUnmarshalDouble(t *testing.T) {
+	t.Parallel()
 	for _, test := range doubleTests {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
 			typeInfo, data := buildUDT(reflect.ValueOf(test.Value).Type(), test.FieldTypeInfo, test.Data, false)
 			value := reflect.New(reflect.TypeOf(test.Value))
 			err := gocql.Unmarshal(typeInfo, data, value.Interface())

--- a/tests/cql_types.go
+++ b/tests/cql_types.go
@@ -349,15 +349,17 @@ type CQLListTypes struct {
 	NamedStringArrayPtr *NamedStringArray
 }
 
-type NamedBytes []byte
-type NamedStringSlice []string
-type NamedStringArray [5]string
-
-type CustomString string
+type (
+	NamedBytes       []byte
+	NamedStringSlice []string
+	NamedStringArray [5]string
+	CustomString     string
+)
 
 func (c CustomString) MarshalCQL(info gocql.TypeInfo) ([]byte, error) {
 	return []byte(strings.ToLower(string(c))), nil
 }
+
 func (c *CustomString) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
 	*c = CustomString(strings.ToUpper(string(data)))
 	return nil

--- a/tests/data.go
+++ b/tests/data.go
@@ -238,8 +238,10 @@ type unexportedStruct struct {
 	Value string
 }
 
-var unexportedStructValue = unexportedStruct{"test"}
-var unexportedStructString = `{"Value":"test"}`
+var (
+	unexportedStructValue  = unexportedStruct{"test"}
+	unexportedStructString = `{"Value":"test"}`
+)
 
 type ExcludedField struct {
 	Process       bool `json:"process"`
@@ -310,8 +312,10 @@ var mapsValue = Maps{
 	CustomMap: map[Str]Str{"c": "d"},
 }
 
-type NamedSlice []Str
-type NamedMap map[Str]Str
+type (
+	NamedSlice []Str
+	NamedMap   map[Str]Str
+)
 
 type DeepNest struct {
 	SliceMap         map[Str][]Str


### PR DESCRIPTION
matoous/golangci-lint-action is deprecated,
official golangci/golangci-lint-action should
be used instead. Update the lint.yml github
workflow.