### PR TITLE
Fix marshaling UDT with unknown field

### DIFF
--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -192,7 +192,7 @@ func (g *Generator) genStructEncoder(t reflect.Type) error {
 		fmt.Fprintf(g.out, "      return fmt.Errorf(\"unknown field: %%s\", udtElement.Name)")
 	} else {
 		fmt.Fprintln(g.out, "    default:")
-		fmt.Fprintln(g.out, "      marshal.AppendBytes(buf, nil)")
+		fmt.Fprintln(g.out, "      buf = marshal.AppendBytes(buf, nil)")
 	}
 	fmt.Fprintln(g.out, "    }")
 	fmt.Fprintln(g.out, "  }")


### PR DESCRIPTION
When we have a field in the UDT where we don't have corresponding
field in the Go struct, we need to write null. There was missing
assignment in the default case, so the null was written over
by additional fields.