### PR TITLE
Bump Go version used in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.13, 1.14, 1.15]
+        go: [1.15, 1.16]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1


### PR DESCRIPTION
1.15 and 1.16 are the only supported versions.